### PR TITLE
feat: RST-28 implement code ordering widget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,4 @@ dist
 coverage/
 .vercel
 .env*.local
+.idea/

--- a/src/utils/create-element.ts
+++ b/src/utils/create-element.ts
@@ -1,0 +1,38 @@
+export function createElement<K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  options?: {
+    className?: string;
+    textContent?: string;
+    attrs?: Partial<HTMLElementTagNameMap[K]>;
+    dataset?: Record<string, string>;
+    children?: (HTMLElement | string)[];
+  },
+): HTMLElementTagNameMap[K] {
+  const element = document.createElement(tag);
+
+  if (options?.className !== undefined) {
+    element.className = options.className;
+  }
+
+  if (options?.textContent !== undefined) {
+    element.textContent = options.textContent;
+  }
+
+  if (options?.attrs !== undefined) {
+    Object.assign(element, options.attrs);
+  }
+
+  if (options?.dataset !== undefined) {
+    for (const [key, value] of Object.entries(options.dataset)) {
+      element.dataset[key] = value;
+    }
+  }
+
+  if (options?.children !== undefined) {
+    for (const child of options.children) {
+      element.append(child);
+    }
+  }
+
+  return element;
+}

--- a/src/widgets/code-ordering.widget/code-ordering.strategy.ts
+++ b/src/widgets/code-ordering.widget/code-ordering.strategy.ts
@@ -1,7 +1,10 @@
 import { WidgetStrategy } from "../../interfaces/widget-strategy.interface.js";
-import { CodeOrderingAnswer } from "../../interfaces/widget-user-answer.interfaces.js";
 import { CodeOrderingWidget } from "../../types/widget.type.js";
 import codeOrderingWidget from "./code-ordering.widget.js";
+
+export type CodeOrderingAnswer = {
+  order: number[];
+};
 
 export const codeOrderingStrategy: WidgetStrategy<
   CodeOrderingWidget,
@@ -14,6 +17,12 @@ export const codeOrderingStrategy: WidgetStrategy<
   },
 
   validate(widget, answer) {
-    return answer.answer === widget.payload.correctOrder;
+    const correctOrder = widget.payload.correctOrder;
+
+    if (answer.order.length !== correctOrder.length) {
+      return false;
+    }
+
+    return answer.order.every((itemIndex, i) => itemIndex === correctOrder[i]);
   },
 };

--- a/src/widgets/code-ordering.widget/code-ordering.widget.css
+++ b/src/widgets/code-ordering.widget/code-ordering.widget.css
@@ -1,5 +1,69 @@
-.practice__code-ordering-widget-container {
+.code-ordering {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 12px;
+}
+
+.code-ordering__list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
+  padding: 12px;
+  background: #111;
+  border-radius: 8px;
+}
+
+.code-ordering__item {
+  padding: 10px 12px;
+  border-radius: 6px;
+
+  background: #1e1e1e;
+  color: #eaeaea;
+
+  font-family: monospace;
+  font-size: 14px;
+  line-height: 1.4;
+
+  cursor: grab;
+  user-select: none;
+
+  transition:
+    transform 0.15s ease,
+    background 0.15s ease;
+}
+
+.code-ordering__item:hover {
+  background: #2a2a2a;
+}
+
+.code-ordering__item:active {
+  cursor: grabbing;
+}
+
+.dragging {
+  opacity: 0.5;
+}
+
+.sortable-chosen {
+  background: #333;
+}
+
+.sortable-drag {
+  transform: scale(1.03);
+  z-index: 10;
+}
+
+.code-ordering__item.correct {
+  background: #1f7a1f !important;
+  color: #d4ffd4;
+}
+
+.code-ordering__item.wrong {
+  background: #7a1f1f !important;
+  color: #ffd4d4;
+}
+
+.code-ordering button {
+  align-self: flex-start;
 }

--- a/src/widgets/code-ordering.widget/code-ordering.widget.ts
+++ b/src/widgets/code-ordering.widget/code-ordering.widget.ts
@@ -1,67 +1,90 @@
-import {
-  CLASS_NAME,
-  EVENT,
-  HEADINGS_THREE,
-  HEADINGS_TWO,
-} from "../../constants.js";
-import { CodeOrderingPayload } from "../../interfaces/widget-payload.interfaces.js";
-import { CodeOrderingAnswer } from "../../interfaces/widget-user-answer.interfaces.js";
-import {
-  CLASS_NAMES_PRACTICE,
-  STRING_CONSTANTS_PRACTICE,
-} from "../../pages/practice.page/practice.page.js";
-import ButtonCreator from "../../utils/button/button-creator.js";
-import ElementCreator from "../../utils/element-creator.js";
-import HeadingsCreator from "../../utils/headings/headings-creator.js";
-import ParagraphCreator from "../../utils/paragraph/paragraph-creator.js";
+import Sortable from "sortablejs";
+import { createElement } from "../../utils/create-element.js";
+
 import "./code-ordering.widget.css";
+
+type CodeOrderingPayload = {
+  title: string;
+  description: string;
+  lines: string[];
+  correctOrder: number[];
+};
+
+type CodeOrderingAnswer = {
+  order: number[];
+};
 
 export default function codeOrderingWidget(
   payload: CodeOrderingPayload,
   onAnswer: (answer: CodeOrderingAnswer) => void,
 ): HTMLElement {
-  const codeOrderingWidgetContainer = new ElementCreator({
-    classes: [
-      CLASS_NAMES_PRACTICE.codeOrderingWidgetContainer,
-      CLASS_NAME.cardElement,
-    ],
-  }).getElement();
+  const items = payload.lines
+    .map((line, index) => ({ line, index }))
+    .sort(() => Math.random() - 0.5);
 
-  new HeadingsCreator(HEADINGS_TWO, {
-    parent: codeOrderingWidgetContainer,
-    text: "Code Ordering Widget",
-  }).getElement();
-
-  new HeadingsCreator(HEADINGS_THREE, {
-    parent: codeOrderingWidgetContainer,
-    text: payload.title,
-  }).getElement();
-
-  new ParagraphCreator({
-    parent: codeOrderingWidgetContainer,
-    text: payload.description,
-  }).getElement();
-
-  new ParagraphCreator({
-    parent: codeOrderingWidgetContainer,
-    text: payload.lines.join(""),
-  }).getElement();
-
-  const submitButton = new ButtonCreator({
-    text: STRING_CONSTANTS_PRACTICE.submit,
-    classes: [CLASS_NAME.button],
-    parent: codeOrderingWidgetContainer,
-  }).getElement();
-
-  const selectedAnswerIndex: CodeOrderingAnswer = {
-    answer: [0, 1, 2, 3, 4, 5, 6],
-  };
-
-  submitButton.addEventListener(EVENT.click, () => {
-    onAnswer(selectedAnswerIndex);
-    submitButton.classList.add(CLASS_NAME.noActive);
-    submitButton.disabled = true;
+  const list = createElement("div", {
+    className: "code-ordering__list",
   });
 
-  return codeOrderingWidgetContainer;
+  for (const item of items) {
+    const el = createElement("div", {
+      className: "code-ordering__item",
+      textContent: item.line,
+      dataset: {
+        index: String(item.index),
+      },
+    });
+
+    list.append(el);
+  }
+
+  const button = createElement("button", {
+    className: "button", // 👈 добавили класс
+    textContent: "Submit",
+    attrs: {
+      disabled: true,
+    },
+  });
+
+  Sortable.create(list, {
+    animation: 150,
+    ghostClass: "dragging",
+    onChange: () => {
+      button.disabled = false;
+    },
+  });
+
+  button.addEventListener("click", () => {
+    const order: number[] = [...list.children].map((el) =>
+      Number((el as HTMLElement).dataset.index),
+    );
+
+    for (const [i, el] of [...list.children].entries()) {
+      const index = Number((el as HTMLElement).dataset.index);
+
+      el.classList.remove("correct", "wrong");
+
+      if (index === payload.correctOrder[i]) {
+        el.classList.add("correct");
+      } else {
+        el.classList.add("wrong");
+      }
+    }
+
+    button.disabled = true;
+
+    onAnswer({ order });
+  });
+
+  const container = createElement("div", {
+    className: "code-ordering",
+    children: [
+      createElement("h3", { textContent: payload.title }),
+      createElement("p", { textContent: payload.description }),
+      list,
+      button,
+    ],
+  });
+
+  return container;
 }


### PR DESCRIPTION
Code Ordering WIdget

Добавил новый интерактивный виджет, в котором пользователь должен расставить строки кода в правильном порядке. При рендере строки перемешиваются, после чего их можно перетаскивать с помощью drag & drop. После нажатия на кнопку Submit собирается текущий порядок, он сравнивается с правильным, и в интерфейсе подсвечиваются корректные и некорректные позиции.